### PR TITLE
`zutil.getzoneattr(zonename, attrname, function (err, attr))`

### DIFF
--- a/test/attr.test.js
+++ b/test/attr.test.js
@@ -1,0 +1,80 @@
+//
+// Copyright 2019 Joyent, Inc.
+//
+
+//
+// Test the methods related to getting zone attributes.
+// These can only run in the "global" zone.
+//
+// Assumptions:
+// - There is at least a single non-global zone with which we can test.
+// - The first non-global zone (from `zoneadm list -p`) has a 
+//   'create-timestamp' attr -- which is typically true for SmartOS-y zones.
+
+var child_process = require('child_process');
+var exec = child_process.exec;
+var execSync = child_process.execSync;
+var test = require('tap').test;
+
+var zutil = require('../');
+
+
+var zonename = execSync('zonename', {encoding: 'utf-8'}).trim();
+var OPTS = {
+    skip: (zonename !== 'global' 
+        && 'must run in global zone to test getting attrs')
+};
+
+test('attr-related functions', OPTS, function (suite) {
+    var testZoneName;
+
+    suite.test('setup', function (t) {
+        // Select the first non-global zone for testing.
+        exec('zoneadm list -p | head -2 | tail -1 | cut -d: -f2',
+            function (err, stdout, stderr) {
+                t.error(err);
+                t.notOk(stderr);
+                testZoneName = stdout.trim();
+                if (!testZoneName) {
+                    OPTS.skip = 'cannot find non-global zone with which to test';
+                } else {
+                    t.comment('testing with zone ' + testZoneName);
+                }
+                t.end();
+            });
+    });
+
+    suite.test('error cases', OPTS, function (t) {
+        t.throws(function () { zutil.getzoneattr(); },
+            /incorrect number of arguments/);
+        t.end();
+    });
+
+    suite.test('no such zone', function (t) {
+        zutil.getzoneattr('nosuchzone', 'create-timestamp', function (err, _) {
+            t.ok(err);
+            t.equal(err.message, 'nosuchzone: No such zone configured');
+            t.end();
+        }); 
+    });
+
+    suite.test('no such attr', function (t) {
+        // TODO: This second call to getzoneattr crashes.
+        zutil.getzoneattr(testZoneName, 'nosuchattr', function (err, attr) {
+            t.ok(err);
+            t.equal(err.message, 'nosuchzone: No such zone configured');
+            t.end();
+        }); 
+    });
+
+    suite.test('zone_get_attr', function (t) {
+        zutil.getzoneattr(testZoneName, 'create-timestamp', function (err, attr) {
+            t.error(err);
+            t.deepEqual(attr, {name: 'create-timestamp', type: 'string'});
+            t.ok(attr.value);
+            t.end();
+        }); 
+    });
+
+    suite.end();
+});


### PR DESCRIPTION
This attempts to add `zutil.getzoneattr(zonename, attrname, function (err, attr))`. However, it crashes on second call. It crashes on *first* call if `UMEM_DEBUG=default` is used. Details below.

After some time (a day on my own, a morning with jbk), I've given up. This method isn't *needed* by Triton/Manta usage of this module (https://github.com/joyent/node-zutil/blob/master/CHANGES.md#200 describes a workaround).  As well, "libzonecfg.h" isn't documented in illumos which means it is an unstable API. As well, my impression is that it is not threadsafe (whether by itself or, more my impression, its usage of libxml2).

### crash details

1. build this module in a zone (where getting a node v6 or later and gcc from pkgsrc is easier)
2. go to the global zone to run the following (because the libzonecfg.h methods being used are only supported in the global zone)
3. get a GZ-usable build of node v6 (You can use Triton's sdcnode builds. Here is one: <https://download.joyent.com/pub/build/sdcnode/c2c31b00-1d60-11e9-9a77-ff9f06554b0f/master-latest/sdcnode/sdcnode-v6.17.0-gz-c2c31b00-1d60-11e9-9a77-ff9f06554b0f-master-20190322T134555Z-g265fc63.tgz>)
3. run the following:

```
[root@headnode (staging-1) /zones/5d4f7599-a991-6b35-dd44-d91936957a6b/root/root/joy/node-zutil]# ../node-zonecfg/tmp/gz/node/bin/node
> var zutil = require('.')
undefined
>
> zutil.getzoneattr('5d4f7599-a991-6b35-dd44-d91936957a6b', 'owner-uuid', console.log)
undefined
> null { name: 'owner-uuid',
  type: 'string',
  value: '752af047-c456-4f1b-9baf-ae31273bef89' }

> zutil.getzoneattr('5d4f7599-a991-6b35-dd44-d91936957a6b', 'owner-uuid', console.log)
Segmentation Fault (core dumped)
```

Look at the core:

```
[root@headnode (staging-1) /zones/global/cores]# mdb $(ls -t | head -1)
Loading modules: [ libumem.so.1 libc.so.1 ld.so.1 ]
> ::stack
libc.so.1`strncmp+0x26()
libxml2.so.2`xmlParserInputBufferCreateFilename+0x45()
libxml2.so.2`xmlNewInputFromFile+0x73()
libxml2.so.2`xmlDefaultExternalEntityLoader+0x10a()
libxml2.so.2`xmlLoadExternalEntity+0xa9()
libxml2.so.2`xmlCreateURLParserCtxt+0x81()
libxml2.so.2`xmlCreateFileParserCtxt+0x1d()
libxml2.so.2`xmlSAXParseFileWithData+0x28()
libxml2.so.2`xmlSAXParseFile+0x2f()
libxml2.so.2`xmlParseFile+0x22()
libzonecfg.so.1`zonecfg_get_handle_impl+0x32(25cb010, fffffbffed781120, 26af3f0)
libzonecfg.so.1`zonecfg_get_handle+0x5a(25cb010, 26af3f0)
zutil_bindings.node`_zu_getzoneattr_execute+0x33()
worker+0xa1()
libc.so.1`_thrp_setup+0x8a(fffffbffef034240)
libc.so.1`_lwp_start()
```

That is always the stack.

A working theory from myself and jbk debugging this for a while from http://xmlsoft.org/threads.html

> There is however a couple of things to do to ensure it:
> 
>   -  configure the library accordingly using the --with-threads options
>   -  call xmlInitParser() in the "main" thread before using any of the libxml2 API (except possibly selecting a different memory allocator)

I don't know if/how to ensure/check that for libzonecfg.so.  After a while we gave up for the reasons given above. I've created this PR to record the details and move on.
